### PR TITLE
feat: Add Join support to DeleteBuilder

### DIFF
--- a/delete.go
+++ b/delete.go
@@ -14,6 +14,7 @@ type deleteData struct {
 	RunWith           BaseRunner
 	Prefixes          []Sqlizer
 	From              string
+	Joins             []Sqlizer
 	WhereParts        []Sqlizer
 	OrderBys          []string
 	Limit             string
@@ -47,6 +48,14 @@ func (d *deleteData) ToSql() (sqlStr string, args []interface{}, err error) {
 
 	sql.WriteString("DELETE FROM ")
 	sql.WriteString(d.From)
+
+	if len(d.Joins) > 0 {
+		sql.WriteString(" ")
+		args, err = appendToSql(d.Joins, sql, " ", args)
+		if err != nil {
+			return
+		}
+	}
 
 	if len(d.WhereParts) > 0 {
 		sql.WriteString(" WHERE ")
@@ -144,6 +153,36 @@ func (b DeleteBuilder) PrefixExpr(expr Sqlizer) DeleteBuilder {
 // From sets the table to be deleted from.
 func (b DeleteBuilder) From(from string) DeleteBuilder {
 	return builder.Set(b, "From", from).(DeleteBuilder)
+}
+
+// JoinClause adds a join clause to the query.
+func (b DeleteBuilder) JoinClause(pred interface{}, args ...interface{}) DeleteBuilder {
+	return builder.Append(b, "Joins", newPart(pred, args...)).(DeleteBuilder)
+}
+
+// Join adds a JOIN clause to the query.
+func (b DeleteBuilder) Join(join string, rest ...interface{}) DeleteBuilder {
+	return b.JoinClause("JOIN "+join, rest...)
+}
+
+// LeftJoin adds a LEFT JOIN clause to the query.
+func (b DeleteBuilder) LeftJoin(join string, rest ...interface{}) DeleteBuilder {
+	return b.JoinClause("LEFT JOIN "+join, rest...)
+}
+
+// RightJoin adds a RIGHT JOIN clause to the query.
+func (b DeleteBuilder) RightJoin(join string, rest ...interface{}) DeleteBuilder {
+	return b.JoinClause("RIGHT JOIN "+join, rest...)
+}
+
+// InnerJoin adds a INNER JOIN clause to the query.
+func (b DeleteBuilder) InnerJoin(join string, rest ...interface{}) DeleteBuilder {
+	return b.JoinClause("INNER JOIN "+join, rest...)
+}
+
+// CrossJoin adds a CROSS JOIN clause to the query.
+func (b DeleteBuilder) CrossJoin(join string, rest ...interface{}) DeleteBuilder {
+	return b.JoinClause("CROSS JOIN "+join, rest...)
 }
 
 // Where adds WHERE expressions to the query.

--- a/delete_test.go
+++ b/delete_test.go
@@ -10,6 +10,12 @@ func TestDeleteBuilderToSql(t *testing.T) {
 	b := Delete("").
 		Prefix("WITH prefix AS ?", 0).
 		From("a").
+		JoinClause("CROSS JOIN j1").
+		Join("j2").
+		LeftJoin("j3").
+		RightJoin("j4").
+		InnerJoin("j5").
+		CrossJoin("j6").
 		Where("b = ?", 1).
 		OrderBy("c").
 		Limit(2).
@@ -21,7 +27,14 @@ func TestDeleteBuilderToSql(t *testing.T) {
 
 	expectedSql :=
 		"WITH prefix AS ? " +
-			"DELETE FROM a WHERE b = ? ORDER BY c LIMIT 2 OFFSET 3 " +
+			"DELETE FROM a " +
+			"CROSS JOIN j1 " +
+			"JOIN j2 " +
+			"LEFT JOIN j3 " +
+			"RIGHT JOIN j4 " +
+			"INNER JOIN j5 " +
+			"CROSS JOIN j6 " +
+			"WHERE b = ? ORDER BY c LIMIT 2 OFFSET 3 " +
 			"RETURNING ?"
 	assert.Equal(t, expectedSql, sql)
 


### PR DESCRIPTION
This copies the implementation of join clauses from SelectBuilder (and our UpdateBuilder) onto DeleteBuilder.